### PR TITLE
feature/RMTP-120-Support-for-Persisting-Assemblies-in-NetCore

### DIFF
--- a/Core.UnitTests/CodeGeneration/ReflectionEmit/ModuleBuilderFactoryTest.cs
+++ b/Core.UnitTests/CodeGeneration/ReflectionEmit/ModuleBuilderFactoryTest.cs
@@ -71,7 +71,7 @@ namespace Remotion.TypePipe.UnitTests.CodeGeneration.ReflectionEmit
     public void CreateModuleBuilder_AppliesTypePipeAssemblyAttribute ()
     {
       var assemblyName = c_assemblyName + Guid.NewGuid();
-      _factory.CreateModuleBuilder (assemblyName, assemblyDirectoryOrNull: null, strongNamed: false, keyFilePathOrNull: null);
+      var moduleBuilder = _factory.CreateModuleBuilder (assemblyName, assemblyDirectoryOrNull: null, strongNamed: false, keyFilePathOrNull: null);
 
       var assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(a => a.GetName().Name == assemblyName);
       Assert.That (assembly, Is.Not.Null);

--- a/Core.UnitTests/CodeGeneration/ReflectionEmit/ModuleBuilderFactoryTest.cs
+++ b/Core.UnitTests/CodeGeneration/ReflectionEmit/ModuleBuilderFactoryTest.cs
@@ -47,6 +47,15 @@ namespace Remotion.TypePipe.UnitTests.CodeGeneration.ReflectionEmit
 
       _currentDirectory = Environment.CurrentDirectory;
     }
+
+    [TearDown]
+    public void TearDown ()
+    {
+      var assemblyPath = Path.Combine (_currentDirectory, c_assemblyFileName);
+      if (File.Exists (assemblyPath))
+        File.Delete (assemblyPath);
+    }
+
     [Test]
     public void CreateModuleBuilder ()
     {

--- a/Core/CodeGeneration/ReflectionEmit/Abstractions/AssemblyBuilderAdapter.cs
+++ b/Core/CodeGeneration/ReflectionEmit/Abstractions/AssemblyBuilderAdapter.cs
@@ -20,15 +20,29 @@ using Remotion.Utilities;
 
 namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit.Abstractions
 {
+#if NET9_0_OR_GREATER
+  /// <summary>
+  /// Adapts <see cref="PersistedAssemblyBuilder"/> with the <see cref="IAssemblyBuilder"/> interface.
+  /// </summary>
+#else
   /// <summary>
   /// Adapts <see cref="AssemblyBuilder"/> with the <see cref="IAssemblyBuilder"/> interface.
   /// </summary>
+#endif
   public class AssemblyBuilderAdapter : BuilderAdapterBase, IAssemblyBuilder
   {
+#if NET9_0_OR_GREATER
+    private readonly PersistedAssemblyBuilder _assemblyBuilder;
+#else
     private readonly AssemblyBuilder _assemblyBuilder;
+#endif
     private readonly ModuleBuilder _moduleBuilder;
 
+#if NET9_0_OR_GREATER
+    public AssemblyBuilderAdapter (PersistedAssemblyBuilder assemblyBuilder, ModuleBuilder moduleBuilder)
+#else
     public AssemblyBuilderAdapter (AssemblyBuilder assemblyBuilder, ModuleBuilder moduleBuilder)
+#endif
         : base (ArgumentUtility.CheckNotNull ("assemblyBuilder", assemblyBuilder).SetCustomAttribute)
     {
       ArgumentUtility.CheckNotNull ("moduleBuilder", moduleBuilder);
@@ -49,7 +63,7 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit.Abstractions
 
     public string SaveToDisk ()
     {
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK || NET9_0_OR_GREATER
       // Scope name is the module name or file name, i.e., assembly name + '.dll'.
       _assemblyBuilder.Save (_moduleBuilder.ScopeName);
 

--- a/Core/CodeGeneration/ReflectionEmit/Abstractions/AssemblyBuilderAdapter.cs
+++ b/Core/CodeGeneration/ReflectionEmit/Abstractions/AssemblyBuilderAdapter.cs
@@ -15,6 +15,7 @@
 // under the License.
 // 
 using System;
+using System.IO;
 using System.Reflection.Emit;
 using Remotion.Utilities;
 
@@ -33,22 +34,29 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit.Abstractions
   {
 #if NET9_0_OR_GREATER
     private readonly PersistedAssemblyBuilder _assemblyBuilder;
+    private readonly string _assemblyDirectory;
 #else
     private readonly AssemblyBuilder _assemblyBuilder;
 #endif
     private readonly ModuleBuilder _moduleBuilder;
 
 #if NET9_0_OR_GREATER
-    public AssemblyBuilderAdapter (PersistedAssemblyBuilder assemblyBuilder, ModuleBuilder moduleBuilder)
+    public AssemblyBuilderAdapter (PersistedAssemblyBuilder assemblyBuilder, ModuleBuilder moduleBuilder, string assemblyDirectory)
 #else
     public AssemblyBuilderAdapter (AssemblyBuilder assemblyBuilder, ModuleBuilder moduleBuilder)
 #endif
         : base (ArgumentUtility.CheckNotNull ("assemblyBuilder", assemblyBuilder).SetCustomAttribute)
     {
       ArgumentUtility.CheckNotNull ("moduleBuilder", moduleBuilder);
+#if NET9_0_OR_GREATER
+      ArgumentUtility.CheckNotNullOrEmpty ("assemblyDirectory", assemblyDirectory);
+#endif
 
       _assemblyBuilder = assemblyBuilder;
       _moduleBuilder = moduleBuilder;
+#if NET9_0_OR_GREATER
+      _assemblyDirectory = assemblyDirectory;
+#endif
     }
 
     public string AssemblyName
@@ -61,14 +69,30 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit.Abstractions
       get { return _assemblyBuilder.GetName ().GetPublicKey (); }
     }
 
+#if NET9_0_OR_GREATER
+    public string AssemblyDirectory
+    {
+      get { return _assemblyDirectory; }
+    }
+#endif
+
     public string SaveToDisk ()
     {
-#if NETFRAMEWORK || NET9_0_OR_GREATER
+#if NETFRAMEWORK
       // Scope name is the module name or file name, i.e., assembly name + '.dll'.
       _assemblyBuilder.Save (_moduleBuilder.ScopeName);
 
       // This is the absolute path to the module, which is also the assembly file path for single-module assemblies.
       return _moduleBuilder.FullyQualifiedName;
+#elif NET9_0_OR_GREATER
+      // Scope name is the module name or file name, i.e., assembly name + '.dll'.
+      var modulePath = Path.Combine (_assemblyDirectory, _moduleBuilder.ScopeName);
+      using (var stream = new FileStream (modulePath, FileMode.Create, FileAccess.Write, FileShare.Read))
+      {
+        _assemblyBuilder.Save (stream);
+      }
+
+      return modulePath;
 #else
       throw new PlatformNotSupportedException ("Assembly persistence is not supported.");
 #endif

--- a/Core/CodeGeneration/ReflectionEmit/Abstractions/ModuleBuilderAdapter.cs
+++ b/Core/CodeGeneration/ReflectionEmit/Abstractions/ModuleBuilderAdapter.cs
@@ -39,10 +39,15 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit.Abstractions
       get { return _assemblyBuilder; }
     }
 
+#if NET9_0_OR_GREATER
+    public ModuleBuilderAdapter (ModuleBuilder moduleBuilder, string assemblyDirectory)
+#else
     public ModuleBuilderAdapter (ModuleBuilder moduleBuilder)
+#endif
         : base (ArgumentUtility.CheckNotNull ("moduleBuilder", moduleBuilder).SetCustomAttribute)
     {
 #if NET9_0_OR_GREATER
+      ArgumentUtility.CheckNotNullOrEmpty ("assemblyDirectory", assemblyDirectory);
       Assertion.IsTrue (moduleBuilder.Assembly is PersistedAssemblyBuilder);
 #else
       Assertion.IsTrue (moduleBuilder.Assembly is AssemblyBuilder);
@@ -50,9 +55,9 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit.Abstractions
 
       _moduleBuilder = moduleBuilder;
 #if NET9_0_OR_GREATER
-      _assemblyBuilder = new AssemblyBuilderAdapter ((PersistedAssemblyBuilder) moduleBuilder.Assembly, moduleBuilder);
+      _assemblyBuilder = new AssemblyBuilderAdapter ((PersistedAssemblyBuilder) moduleBuilder.Assembly, moduleBuilder, assemblyDirectory);
 #else
-      _assemblyBuilder = new AssemblyBuilderAdapter (((AssemblyBuilder) moduleBuilder.Assembly), moduleBuilder);
+      _assemblyBuilder = new AssemblyBuilderAdapter ((AssemblyBuilder) moduleBuilder.Assembly, moduleBuilder);
 #endif
     }
 

--- a/Core/CodeGeneration/ReflectionEmit/Abstractions/ModuleBuilderAdapter.cs
+++ b/Core/CodeGeneration/ReflectionEmit/Abstractions/ModuleBuilderAdapter.cs
@@ -42,10 +42,18 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit.Abstractions
     public ModuleBuilderAdapter (ModuleBuilder moduleBuilder)
         : base (ArgumentUtility.CheckNotNull ("moduleBuilder", moduleBuilder).SetCustomAttribute)
     {
+#if NET9_0_OR_GREATER
+      Assertion.IsTrue (moduleBuilder.Assembly is PersistedAssemblyBuilder);
+#else
       Assertion.IsTrue (moduleBuilder.Assembly is AssemblyBuilder);
+#endif
 
       _moduleBuilder = moduleBuilder;
+#if NET9_0_OR_GREATER
+      _assemblyBuilder = new AssemblyBuilderAdapter ((PersistedAssemblyBuilder) moduleBuilder.Assembly, moduleBuilder);
+#else
       _assemblyBuilder = new AssemblyBuilderAdapter (((AssemblyBuilder) moduleBuilder.Assembly), moduleBuilder);
+#endif
     }
 
     [CLSCompliant (false)]

--- a/Core/CodeGeneration/ReflectionEmit/ModuleBuilderFactory.cs
+++ b/Core/CodeGeneration/ReflectionEmit/ModuleBuilderFactory.cs
@@ -94,8 +94,12 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit
       var moduleBuilder = assemblyBuilder.DefineDynamicModule (moduleName);
 #endif
 
+#if NET9_0_OR_GREATER
+      var assmeblyDirectory =  assemblyDirectoryOrNull ?? Environment.CurrentDirectory;
+      var moduleBuilderAdapter = new ModuleBuilderAdapter (moduleBuilder, assmeblyDirectory);
+#else
       var moduleBuilderAdapter = new ModuleBuilderAdapter (moduleBuilder);
-
+#endif
       var typePipeAttribute = new CustomAttributeDeclaration (s_typePipeAssemblyAttributeCtor, new object[] { _participantConfigurationID });
       moduleBuilderAdapter.AssemblyBuilder.SetCustomAttribute (typePipeAttribute);
 

--- a/Core/CodeGeneration/ReflectionEmit/ModuleBuilderFactory.cs
+++ b/Core/CodeGeneration/ReflectionEmit/ModuleBuilderFactory.cs
@@ -27,11 +27,19 @@ using Remotion.Utilities;
 
 namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit
 {
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
   /// <summary>
   /// This class creates instances of <see cref="IModuleBuilder"/>.
   /// </summary>
   /// <remarks> The module will be created with <see cref="AssemblyBuilderAccess.RunAndSave"/> and the <c>emitSymbolInfo</c> flag set to
+  /// <see langword="true"/>.
+  /// </remarks>
+  /// <threadsafety static="true" instance="true"/>
+#elif NET9_0_OR_GREATER
+  /// <summary>
+  /// This class creates instances of <see cref="IModuleBuilder"/>.
+  /// </summary>
+  /// <remarks> The module will be created with <see cref="PersistedAssemblyBuilder"/> and the <c>emitSymbolInfo</c> flag set to
   /// <see langword="true"/>.
   /// </remarks>
   /// <threadsafety static="true" instance="true"/>
@@ -70,8 +78,10 @@ namespace Remotion.TypePipe.CodeGeneration.ReflectionEmit
 #endif
       }
 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
       var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly (assemName, AssemblyBuilderAccess.RunAndSave, assemblyDirectoryOrNull);
+#elif NET9_0_OR_GREATER
+      var assemblyBuilder = new PersistedAssemblyBuilder (new AssemblyName(assemblyName), typeof(object).Assembly);
 #else
       var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly (assemName, AssemblyBuilderAccess.Run);
 #endif

--- a/Core/Dlr/Compiler/AssemblyGen.cs
+++ b/Core/Dlr/Compiler/AssemblyGen.cs
@@ -60,13 +60,13 @@ namespace System.Linq.Expressions.Compiler {
 
             _myAssembly = AssemblyBuilder.DefineDynamicAssembly (name, AssemblyBuilderAccess.Run, attributes);
 
-#if FEATURE_PDBEMIT
+#if NETFRAMEWORK
             _myModule = _myAssembly.DefineDynamicModule (name.Name, false);
 #else
             _myModule = _myAssembly.DefineDynamicModule (name.Name);
 #endif
 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
             _myAssembly.DefineVersionInfoResource();
 #endif
 

--- a/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifier.cs
+++ b/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifier.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.Diagnostics;
 using System.Reflection;

--- a/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/DotNetSdk20PEVerifyPathSource.cs
+++ b/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/DotNetSdk20PEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk6PEVerifyPathSource.cs
+++ b/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk6PEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk70aPEVerifyPathSource.cs
+++ b/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk70aPEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk71PEVerifyPathSource.cs
+++ b/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk71PEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk80aPEVerifyPathSource.cs
+++ b/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk80aPEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk81aPEVerifyPathSource.cs
+++ b/Development/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk81aPEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/Development/AssemblyTrackingCodeManager.cs
+++ b/Development/AssemblyTrackingCodeManager.cs
@@ -14,10 +14,11 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK || NET9_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using Remotion.Development.UnitTesting;
@@ -67,6 +68,7 @@ namespace Remotion.TypePipe.Development
       }
     }
 
+#if NETFRAMEWORK
     public void PeVerifySavedAssemblies ()
     {
       lock (_lockObject)
@@ -75,6 +77,18 @@ namespace Remotion.TypePipe.Development
           PEVerifier.CreateDefault().VerifyPEFile (assemblyPath);
       }
     }
+#elif NET9_0_OR_GREATER
+    public void ProcessSavedAssemblies (Action<string> processor)
+    {
+      ArgumentUtility.CheckNotNull ("processor", processor);
+
+      lock (_lockObject)
+      {
+        foreach (var assemblyPath in _savedAssemblies)
+          processor (assemblyPath);
+      }
+    }
+#endif
 
     public void DeleteSavedAssemblies ()
     {

--- a/Development/AssemblyTrackingPipelineFactory.cs
+++ b/Development/AssemblyTrackingPipelineFactory.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK || NET9_0_OR_GREATER
 using System;
 using Remotion.TypePipe.Caching;
 using Remotion.TypePipe.CodeGeneration;

--- a/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifier.cs
+++ b/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifier.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.Diagnostics;
 using System.Reflection;

--- a/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/DotNetSdk20PEVerifyPathSource.cs
+++ b/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/DotNetSdk20PEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk6PEVerifyPathSource.cs
+++ b/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk6PEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk70aPEVerifyPathSource.cs
+++ b/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk70aPEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk71PEVerifyPathSource.cs
+++ b/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk71PEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk80aPEVerifyPathSource.cs
+++ b/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk80aPEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk81aPEVerifyPathSource.cs
+++ b/IntegrationTests/App_Packages/Remotion.Development.PEVerifier.Sources.1.17.10.0/PEVerifyPathSources/WindowsSdk81aPEVerifyPathSource.cs
@@ -14,7 +14,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 // 
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
 using System;
 using System.IO;
 using Microsoft.Win32;

--- a/IntegrationTests/IntegrationTestBase.cs
+++ b/IntegrationTests/IntegrationTestBase.cs
@@ -93,9 +93,7 @@ namespace Remotion.TypePipe.IntegrationTests
     [TearDown]
     public virtual void TearDown ()
     {
-#if !FEATURE_ASSEMBLYBUILDER_SAVE
       SkipSavingAndPeVerification();
-#endif
 
       if (_skipSavingAndVerification)
         return;
@@ -196,10 +194,21 @@ namespace Remotion.TypePipe.IntegrationTests
 
     private static void PeVerifyAssembly (string assemblyPath)
     {
-#if FEATURE_ASSEMBLYBUILDER_SAVE
+#if NETFRAMEWORK
       try
       {
         PEVerifier.CreateDefault().VerifyPEFile (assemblyPath);
+      }
+      catch (Exception exception)
+      {
+        Console.WriteLine (exception);
+        throw;
+      }
+#elif NET9_0_OR_GREATER
+      try
+      {
+        // RM-9285
+        // new ILVerify.Verifier()
       }
       catch (Exception exception)
       {

--- a/IntegrationTests/Pipeline/ConcurrencyTest_WithMultipleGenerationThreads.cs
+++ b/IntegrationTests/Pipeline/ConcurrencyTest_WithMultipleGenerationThreads.cs
@@ -126,7 +126,7 @@ namespace Remotion.TypePipe.IntegrationTests.Pipeline
     }
 
     [Test]
-#if !FEATURE_ASSEMBLYBUILDER_SAVE
+#if NET8_0
     [Ignore ("CodeManager.FlushCodeToDisk() is not supported.")]
 #endif
     public void LoadFlushedCodeInParallel_GetTypeIDForAssembledTypeBlocks ()
@@ -159,7 +159,7 @@ namespace Remotion.TypePipe.IntegrationTests.Pipeline
     }
 
     [Test]
-#if !FEATURE_ASSEMBLYBUILDER_SAVE
+#if NET8_0
     [Ignore ("CodeManager.FlushCodeToDisk() is not supported.")]
 #endif
     public void CodeManagerAPIs_FlushIsBlockedUntilAllCodeGenerationIsComplete ()

--- a/IntegrationTests/Pipeline/ConcurrencyTest_WithSingleGenerationThread.cs
+++ b/IntegrationTests/Pipeline/ConcurrencyTest_WithSingleGenerationThread.cs
@@ -92,7 +92,7 @@ namespace Remotion.TypePipe.IntegrationTests.Pipeline
     }
 
     [Test]
-#if !FEATURE_ASSEMBLYBUILDER_SAVE
+#if NET8_0
     [Ignore ("CodeManager.FlushCodeToDisk() is not supported.")]
 #endif
     public void CodeManagerAPIs_CannotRunWhileCodeIsGenerated ()

--- a/IntegrationTests/Pipeline/FlushGeneratedCodeTest.cs
+++ b/IntegrationTests/Pipeline/FlushGeneratedCodeTest.cs
@@ -28,7 +28,7 @@ using Remotion.TypePipe.MutableReflection;
 namespace Remotion.TypePipe.IntegrationTests.Pipeline
 {
   [TestFixture]
-#if !FEATURE_ASSEMBLYBUILDER_SAVE
+#if NET8_0
   [Ignore ("CodeManager.FlushCodeToDisk() is not supported.")]
 #endif
   public class FlushGeneratedCodeTest : IntegrationTestBase

--- a/IntegrationTests/Pipeline/LoadFlushedCodeTest.cs
+++ b/IntegrationTests/Pipeline/LoadFlushedCodeTest.cs
@@ -27,7 +27,7 @@ using Moq;
 namespace Remotion.TypePipe.IntegrationTests.Pipeline
 {
   [TestFixture]
-#if !FEATURE_ASSEMBLYBUILDER_SAVE
+#if NET8_0
   [Ignore ("CodeManager.FlushCodeToDisk() is not supported.")]
 #endif
   public class LoadFlushedCodeTest : IntegrationTestBase

--- a/IntegrationTests/Pipeline/ParticipantStateTest.cs
+++ b/IntegrationTests/Pipeline/ParticipantStateTest.cs
@@ -23,7 +23,7 @@ using Remotion.Development.UnitTesting.IO;
 namespace Remotion.TypePipe.IntegrationTests.Pipeline
 {
   [TestFixture]
-#if !FEATURE_ASSEMBLYBUILDER_SAVE
+#if NET8_0
   [Ignore ("CodeManager.FlushCodeToDisk() is not supported.")]
 #endif
   public class ParticipantStateTest : IntegrationTestBase

--- a/Shared.build.props
+++ b/Shared.build.props
@@ -35,7 +35,7 @@
     <IsPackable>True</IsPackable>
     <TargetFrameworks>net8.0;net9.0;net462</TargetFrameworks>
     <DefineConstants>$(DefineConstants);TypePipe</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net462'">$(DefineConstants);FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_REMOTING;FEATURE_PDBEMIT;FEATURE_STRONGNAMESIGNING</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net462'">$(DefineConstants);FEATURE_REMOTING;FEATURE_PDBEMIT;FEATURE_STRONGNAMESIGNING</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ProjectType)' == 'Documentation'">
@@ -53,7 +53,7 @@
     <IsPackable>False</IsPackable>
     <TargetFrameworks>net8.0;net9.0;net462</TargetFrameworks>
     <DefineConstants>$(DefineConstants)</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net462'">$(DefineConstants);FEATURE_ASSEMBLYBUILDER_SAVE;FEATURE_STRONGNAMESIGNING</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net462'">$(DefineConstants);FEATURE_PDBEMIT;FEATURE_STRONGNAMESIGNING</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Persisted Assemblies can only be used after they are written to disk in .NET 9. This means the existing semantics break completely.